### PR TITLE
Add environment variable for parallel updates which is useful for multi-container app

### DIFF
--- a/main.py
+++ b/main.py
@@ -100,7 +100,7 @@ def update_services(client: DockerClient, apprise: Apprise):
 
             success_message = f'Update successful. Took {elapsed} seconds.'
             apprise.notify(title=f'Service: `{name}`', body=success_message, notify_type=NotifyType.SUCCESS)
-            if getenv('ONE_BY_ONE_UPDATE','') == 'yes':
+            if getenv('PARALLEL_UPDATES', '').lower() in ['false', 'no', 'off', '0']:
                 # When there are more images to update in one pass then update them one by one
                 return
         else:

--- a/main.py
+++ b/main.py
@@ -100,6 +100,9 @@ def update_services(client: DockerClient, apprise: Apprise):
 
             success_message = f'Update successful. Took {elapsed} seconds.'
             apprise.notify(title=f'Service: `{name}`', body=success_message, notify_type=NotifyType.SUCCESS)
+            if getenv('ONE_BY_ONE_UPDATE','') == 'yes':
+                # When there are more images to update in one pass then update them one by one
+                return
         else:
             logger.debug(f'No update found for service \'{name}\'')
 


### PR DESCRIPTION
I had problems with multicontainer app https://github.com/openremote/openremote when updating all
containers at once (this is what our CI/CD pipeline does). This sometimes resulted in corrupted database
and ultimately app crash. With this change we can do only one container at the time spreading the whole
update in time, but there are no crashes.